### PR TITLE
add style to swap order of columns on mobile devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 04.11.2022
+
+### Changed
+
+New feature:
+* Add style to swap the order of columns on mobile devices:
+In a two-column element (e.g. with text in the left column and an image in the right column), a style can be set so that the order of the columns is swapped only on mobile devices. This enables the image to be displayed above the text in mobile view, even if the image remains in the right column in the desktop view.
+
+Improvements:
+* Update labels of spacer style
+
+[1.1.2]: https://github.com/bsi-software/bsi-cx-design-standard-library-web/releases/tag/1.1.2
+
+
 ## [1.1.1] - 21.10.2022
 
 ### Changed

--- a/configs/styles/col-two-order-mobile.js
+++ b/configs/styles/col-two-order-mobile.js
@@ -2,12 +2,14 @@ const {cx} = require('@bsi-cx/design-build');
 
 module.exports = cx.style
   .withIdentifier('col-two-order-mobile-vo40Cv')
-  /*.withLabel('Swap the order of columns on mobile devices')*/
-  .withLabel('Vertausche die Reihenfolge der Spalten auf mobilen Geräten')
+  /*.withLabel('Swap column order')*/
+  .withLabel('Spaltenreihenfolge tauschen')
   .withCssClasses(
     cx.cssClass
+      /*.withLabel('No')*/
       .withLabel('Nein')
       .withCssClass('bsi-mobile-order-default'),
     cx.cssClass
-      .withLabel('Ja')
+      /*.withLabel('On mobile devices')*/
+      .withLabel('Auf mobilen Geräten')
       .withCssClass('bsi-mobile-order-swapped'));

--- a/configs/styles/col-two-order-mobile.js
+++ b/configs/styles/col-two-order-mobile.js
@@ -1,0 +1,13 @@
+const {cx} = require('@bsi-cx/design-build');
+
+module.exports = cx.style
+  .withIdentifier('col-two-order-mobile-vo40Cv')
+  /*.withLabel('Swap the order of columns on mobile devices')*/
+  .withLabel('Vertausche die Reihenfolge der Spalten auf mobilen Geräten')
+  .withCssClasses(
+    cx.cssClass
+      .withLabel('Nein')
+      .withCssClass('bsi-mobile-order-default'),
+    cx.cssClass
+      .withLabel('Ja')
+      .withCssClass('bsi-mobile-order-swapped'));

--- a/configs/styles/spacer.js
+++ b/configs/styles/spacer.js
@@ -6,17 +6,17 @@ module.exports = cx.style
   .withLabel('Grösse des Abstands')
   .withCssClasses(
     cx.cssClass
-      .withLabel('1')
+      .withLabel('4 px')
       .withCssClass('pt-1'),
     cx.cssClass
-      .withLabel('2')
+      .withLabel('8 px')
       .withCssClass('pt-2'),
     cx.cssClass
-      .withLabel('3')
+      .withLabel('16 px')
       .withCssClass('pt-3'),
     cx.cssClass
-      .withLabel('4')
+      .withLabel('24 px')
       .withCssClass('pt-4'),
     cx.cssClass
-      .withLabel('5')
+      .withLabel('48 px')
       .withCssClass('pt-5'));

--- a/content-elements/layout/col-two/index.js
+++ b/content-elements/layout/col-two/index.js
@@ -17,6 +17,7 @@ element.withFile(require('./template.twig'))
   .withStyleConfigs(
     require('../../../configs/styles/col-width'),
     require('../../../configs/styles/col-two-ratio'),
+    require('../../../configs/styles/col-two-order-mobile'),
     require('../../../configs/styles/col-spacing'),
     require('../../../configs/styles/col-gap'),
     require('../../../configs/styles/col-alignment'),

--- a/content-elements/layout/col-two/styles.scss
+++ b/content-elements/layout/col-two/styles.scss
@@ -29,4 +29,11 @@
             }
         }        
     }
+    @media (max-width: $md) {
+        &.bsi-mobile-order-swapped {
+            > .row {
+                flex-direction: column-reverse;
+            }
+        }
+    }
 }

--- a/content-elements/layout/col-two/template.twig
+++ b/content-elements/layout/col-two/template.twig
@@ -1,7 +1,7 @@
 {% apply spaceless %}
     {% set colTwoAlignment = (colTwoAlignment ?: properties.colTwoAlignment) ?: 'bsi-col-align-left' %}
 
-    <div data-bsi-element="col-two-ILRIL0" class="bsi-element-col-two-ILRIL0 bsi-column-element container bsi-ratio-6-6 bsi-space-around-visible bsi-gaps-visible {{ colTwoAlignment }} bsi-bg-color-transparent bsi-opacity-100 bsi-gradient-hide">
+    <div data-bsi-element="col-two-ILRIL0" class="bsi-element-col-two-ILRIL0 bsi-column-element container bsi-ratio-6-6 bsi-mobile-order-default bsi-space-around-visible bsi-gaps-visible {{ colTwoAlignment }} bsi-bg-color-transparent bsi-opacity-100 bsi-gradient-hide">
         <div class="row">
             <div class="col-sm-12 col-md-6 bsi-column bsi-column-1" data-bsi-dropzone="col-two-dropzone-1-aDxFmN">
                 {% block col_two_dropzone_1 %}{% endblock %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsi-cx/design-standard-library-web",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Standard content element library for BSI CX.",
   "license": "MIT",
   "repository": "github:bsi-software/bsi-cx-design-standard-library-web",


### PR DESCRIPTION
New feature:
* Add style to swap the order of columns on mobile devices:
In a two-column element (e.g. with text in the left column and an image in the right column), a style can be set so that the order of the columns is swapped only on mobile devices. This enables the image to be displayed above the text in mobile view, even if the image remains in the right column in the desktop view.

Improvements:
* Update labels of spacer style