### PR TITLE
Make Properties null-safe

### DIFF
--- a/content-elements/base/chart/prototype/chart.js
+++ b/content-elements/base/chart/prototype/chart.js
@@ -44,8 +44,8 @@ Alpine.data('chartElement', () => ({
   ChartConfigColor.of( '#c7f296ff','#c7f29666')
 ]*/
 const colors = [
-    ChartConfigColor.of(window.properties.chartBorderColor1 ?? '#116985ff',window.properties.chartBackgroundColor1 ?? '#11698566'),
-    ChartConfigColor.of(window.properties.chartBorderColor2 ?? '#27aab0ff',window.properties.chartBackgroundColor2 ?? '#27aab066'),
-    ChartConfigColor.of(window.properties.chartBorderColor3 ?? '#94e7a8ff',window.properties.chartBackgroundColor3 ?? '#94e7a866'),
-    ChartConfigColor.of(window.properties.chartBorderColor4 ?? '#c7f296ff',window.properties.chartBackgroundColor4 ?? '#c7f29666')
+    ChartConfigColor.of(window.properties?.chartBorderColor1 ?? '#116985ff',window.properties?.chartBackgroundColor1 ?? '#11698566'),
+    ChartConfigColor.of(window.properties?.chartBorderColor2 ?? '#27aab0ff',window.properties?.chartBackgroundColor2 ?? '#27aab066'),
+    ChartConfigColor.of(window.properties?.chartBorderColor3 ?? '#94e7a8ff',window.properties?.chartBackgroundColor3 ?? '#94e7a866'),
+    ChartConfigColor.of(window.properties?.chartBorderColor4 ?? '#c7f296ff',window.properties?.chartBackgroundColor4 ?? '#c7f29666')
 ];


### PR DESCRIPTION
As reported in Ticket #343211, the window properties are made null-safe