### PR TITLE
Accordion submits form when used within formcontainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Next
 * Export text element with .editor() function where htmlEditorConfig can be customized
+* Accodion trigger button will not trigger form submission, when used within a form container
 
 ## [1.4.6] - 17.05.2024
 * Allow multiple slot finder instances on one site (#383421)

--- a/content-elements/base/accordion/prototype/template.twig
+++ b/content-elements/base/accordion/prototype/template.twig
@@ -6,7 +6,7 @@
 {% set accordionIconPosition = (iconPosition ?: properties.accordionIconPosition) ?: 'start' %} {# must be in ['start', 'end', 'none'] #}
 
 <div data-bsi-element="{{ accordionElementId }}" class="bsi-element-{{ accordionElementId }} inactive" x-data="accordionElement">
-	<button x-init="initAccordion" class="accordion-header element" @click="toggleActive" aria-expanded="false">
+	<button type="button" x-init="initAccordion" class="accordion-header element" @click="toggleActive" aria-expanded="false">
 		{% if accordionIconPosition == 'start' %}
 			{% block icon_before %}
 				<i class="bi inactive bi-plus-lg"></i>


### PR DESCRIPTION
Any Button without a specific type will be treated as type="submit".
Currently the Accordion Element cannot be used within a form container, without it submitting the form.