### PR TITLE
refactor: add default maxlength in  formularfields

### DIFF
--- a/content-elements/form/form-field/prototype/form-field.js
+++ b/content-elements/form/form-field/prototype/form-field.js
@@ -22,6 +22,14 @@ Alpine.data('formField', () => ({
     } else if (['date', 'datetime-local', 'time'].includes(this.inputEl.type)) {
       this._initDateInput();
     }
+
+    if (this.inputEl.type === 'text' || this.inputEl.type === 'email' || this.inputEl.type === 'password') {
+      if (!this.inputEl.hasAttribute("maxlength")) {
+        console.log("Das Element hat kein maxlength Attribute, es wird jetzt geschrieben.")
+        this.inputEl.setAttribute("maxlength", 250);
+      } 
+    }
+      
   },
 
   initRequiredError() {


### PR DESCRIPTION
Auf diese Weise wird jetzt bei Text-, Mail- und Passwortfeldern standardmäßig 250 als maxlength gesetzt, sofern in der Maske nichts eingegeben wird.
Schöner fände ich es, wenn in der Maske dann auch 250 stehen würde, oder zumindest textlich ein Hinweis, dass wenn dort nichts drin steht, ein defaultwert von 250 gesetzt ist.
Das müsste man dann aber vermutlich über das cx lösen.