### PR TITLE
Revert "Bump intl-tel-input from 19.5.7 to 23.0.12"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bootstrap-icons": "^1.11.3",
     "chart.js": "^4.4.1",
     "flatpickr": "^4.6.13",
-    "intl-tel-input": "^23.0.12"
+    "intl-tel-input": "^19.5.3"
   },
   "devDependencies": {
     "@bsi-cx/design-build": "^1.13.3",


### PR DESCRIPTION
Reverts bsi-software/bsi-cx-design-standard-library-web#126