### PR TITLE
Add restrictions to pin-element styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Next
 * Fix aria-states for header-image
+* Fix tabindex for all Elements
 * Alt-Text warning for video
+* Form: remove floating label style
+* Pin-element: Add restrictions to styling
 * Select: Submit empty values
 * Tel: Update onto newest version
-* Form: remove floating label style
-* Fix tabindex for all Elements
 
 ## [1.4.11] - 29.04.2025
 * Fix poll submit

--- a/content-elements/form/form-pin/styles.scss
+++ b/content-elements/form/form-pin/styles.scss
@@ -169,19 +169,19 @@
   input[type=number] {
     -moz-appearance: textfield;
   }
-}
 
-.was-validated .form-control:valid,
-.form-control.is-valid {
-  padding: 10px 10px;
-  background-image: none !important;
-  background-color:#ffff !important;
-}
+  .was-validated .form-control:valid,
+  .form-control.is-valid {
+    padding: 10px 10px;
+    background-image: none;
+    background-color:#ffff;
+  }
 
-.was-validated .form-control:invalid,
-.form-control.is-invalid {
-  padding: 10px 10px;
-  background-image: none !important;
-  background-color: rgb(217, 19, 41, 0.05) !important;
-  border: 1px solid #d91329 !important;
+  .was-validated .form-control:invalid,
+  .form-control.is-invalid {
+    padding: 10px 10px;
+    background-image: none;
+    background-color: rgb(217, 19, 41, 0.05);
+    border: 1px solid #d91329;
+  }
 }


### PR DESCRIPTION
Habe einige !importants entfernt und das Styling allgemein auf das Formular des Pin-Elements eingeschränkt.
Das Styling beeinträchtigt jetzt keine anderen Elemente mehr.

Gerne nochmal mit dem Pin-Element testen.