### PR TITLE
Accessibility form fields - errormessages, date fields and tel-input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Pin-element: Add restrictions to styling
 * Select: Submit empty values
 * Tel: Update onto newest version
+* Update telephone number validation to support fix-line numbers
 
 ## [1.4.11] - 29.04.2025
 * Fix poll submit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fix errormessages screenreader
 * Fix telephon number validation also for fix line numbers
 * Add possibility to change telephone number field input type in properties
+* Add possibility to change date field input type in properties
 * Alt-Text warning for video
 * Form: remove floating label style
 * Pin-element: Add restrictions to styling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Next
 * Fix aria-states for header-image
 * Fix tabindex for all Elements
-* Fix errormessages screenreader
+* Fix errormessages for screenreader
 * Fix telephon number validation also for fix line numbers
 * Add possibility to change telephone number field input type in properties
 * Add possibility to change date field input type in properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Next
 * Fix aria-states for header-image
 * Fix tabindex for all Elements
+* Fix errormessages screenreader
+* Fix telephon number validation also for fix line numbers
+* Add possibility to change telephone number field input type in properties
 * Alt-Text warning for video
 * Form: remove floating label style
 * Pin-element: Add restrictions to styling

--- a/content-elements/form/form-container/form.js
+++ b/content-elements/form/form-container/form.js
@@ -33,17 +33,18 @@ Alpine.data('formElement', () => ({
 
   submitForm(e) {
     this._validateFormFieldTel(); // must be executed before form.checkValidity()
+    this.form.classList.add('was-validated');
     if (!this.form.checkValidity()) {
       e.preventDefault();
       e.stopPropagation();
       this._validateRadioInput();
+      
       this._setAriaValues();
       this._formValidationSummary();
     }
     else {
       this._clearSelectValues();
     }
-    this.form.classList.add('was-validated');
   },
 
   _initFloatingLabels(floatingElement) {
@@ -85,7 +86,7 @@ Alpine.data('formElement', () => ({
   _validateFormFieldTel() {
     this.form.querySelectorAll('.bsi-form-tel-input').forEach(telInput => {
       let visibleInput = telInput.querySelector('input[type=tel]');
-      visibleInput.dispatchEvent(new Event('change'));
+      visibleInput.dispatchEvent(new Event('input'));
     });
   },
 
@@ -103,16 +104,21 @@ Alpine.data('formElement', () => ({
     this.$root.querySelectorAll('select').forEach(select => select.value = select.value || null);
   },
 
+  // set Aria describedby attribute - also relevant in form-tel-input.js and form-field.js
   _setAriaValues() {
     this.$root.querySelectorAll(".bsi-form-element")
       .forEach(inputField => {
-        var input = inputField.querySelector('input, textarea, select');
-        input.setAttribute('aria-invalid', !input.checkValidity());
-        if ('ariaDescribedByElements' in Element.prototype) {
-          // TODO: add info text on-init to describedby-tag. Add errorMessage to info text
-          var errorMessage = Array.from(inputField.querySelectorAll('.invalid-feedback')).filter(errorMessage => window.getComputedStyle(errorMessage).display !== 'none');
-          input.ariaDescribedByElements = errorMessage;
-        }
+          if (inputField.classList.contains("bsi-form-tel-input")) {
+            var input = inputField.querySelector('input.form-control:not([type=hidden]), textarea, select');
+          } else {
+            var input = inputField.querySelector('input:not([type=hidden]), textarea, select');
+          }
+          input.setAttribute('aria-invalid', !input.checkValidity());
+          if ('ariaDescribedByElements' in Element.prototype) {
+            // TODO: add info text on-init to describedby-tag. Add errorMessage to info text
+            var errorMessageElements = Array.from(inputField.querySelectorAll('.invalid-feedback')).filter(errorMessageElement => window.getComputedStyle(errorMessageElement).display !== 'none');
+            input.ariaDescribedByElements = errorMessageElements;
+          }
       })
   },
 

--- a/content-elements/form/form-container/form.js
+++ b/content-elements/form/form-container/form.js
@@ -37,7 +37,7 @@ Alpine.data('formElement', () => ({
       e.preventDefault();
       e.stopPropagation();
       this._validateRadioInput();
-      this._setAriaInvalid();
+      this._setAriaValues();
       this._formValidationSummary();
     }
     else {
@@ -95,21 +95,25 @@ Alpine.data('formElement', () => ({
       let radioInputs = Array.from(radioElement.querySelectorAll('.form-check-input'));
       let radioValid = radioInputs.some(radio => radio.checkValidity());
       var validationElement = radioElement.querySelector('.invalid-feedback');
-      radioElement.setAttribute('aria-invalid', !radioValid);
       this._showValidationMessage(validationElement, !radioValid);
     }
   },
 
-  _setAriaInvalid() {
-    var elements = this.form.querySelectorAll('.bsi-form-element:not(.bsi-form-radio-element)');
-    elements.forEach(element => {
-      let input = element.querySelector('input, select, textarea');
-      input.setAttribute('aria-invalid', !input.checkValidity());
-    });
-  },
-
   _clearSelectValues() {
     this.$root.querySelectorAll('select').forEach(select => select.value = select.value || null);
+  },
+
+  _setAriaValues() {
+    this.$root.querySelectorAll(".bsi-form-element")
+      .forEach(inputField => {
+        var input = inputField.querySelector('input, textarea, select');
+        input.setAttribute('aria-invalid', !input.checkValidity());
+        if ('ariaDescribedByElements' in Element.prototype) {
+          // TODO: add info text on-init to describedby-tag. Add errorMessage to info text
+          var errorMessage = Array.from(inputField.querySelectorAll('.invalid-feedback')).filter(errorMessage => window.getComputedStyle(errorMessage).display !== 'none');
+          input.ariaDescribedByElements = errorMessage;
+        }
+      })
   },
 
   _formValidationSummary() {

--- a/content-elements/form/form-container/form.js
+++ b/content-elements/form/form-container/form.js
@@ -38,7 +38,6 @@ Alpine.data('formElement', () => ({
       e.preventDefault();
       e.stopPropagation();
       this._validateRadioInput();
-      
       this._setAriaValues();
       this._formValidationSummary();
     }

--- a/content-elements/form/form-field-tel/prototype/form-tel-input.js
+++ b/content-elements/form/form-field-tel/prototype/form-tel-input.js
@@ -42,18 +42,15 @@ Alpine.data('telInput', () => ({
     let classList = this.validationElement.classList;
     this.inputField.checkValidity() ? classList.remove('d-block') : classList.add('d-block');
     // set Aria describedby attribute - also relevant in form.js and form-field.js
-    this.inputField.setAttribute("aria-invalid", !logicValid);
-    if (logicValid && !this.inputField.value.trim() === "") {
-      this.inputField.removeAttribute("aria-describedby");
-    } else if ("ariaDescribedByElements" in Element.prototype) {
+    this.inputField.setAttribute('aria-invalid', !logicValid);
+    if (logicValid && !this.inputField.value.trim() === '') {
+      this.inputField.removeAttribute('aria-describedby');
+    } else if ('ariaDescribedByElements' in Element.prototype) {
       var errorMessageElements = Array.from(
-        this.inputField
-          .closest(".bsi-form-element")
-          .querySelectorAll(".invalid-feedback")
-      ).filter(
+        this.inputField.closest('.bsi-form-element').querySelectorAll('.invalid-feedback'))
+      .filter(
         (errorMessageElement) =>
-          window.getComputedStyle(errorMessageElement).display !== "none"
-      );
+          window.getComputedStyle(errorMessageElement).display !== 'none');
       this.inputField.ariaDescribedByElements = errorMessageElements;
     }
   },

--- a/content-elements/form/form-field-tel/prototype/form-tel-input.js
+++ b/content-elements/form/form-field-tel/prototype/form-tel-input.js
@@ -25,8 +25,9 @@ Alpine.data('telInput', () => ({
       countrySearch: onlyCountries.length > 5 || onlyCountries.length == 0,
       loadUtils: () => import('intl-tel-input/build/js/utils.js'),
       hiddenInput: () => ({ phone: name }),
-      separateDialCode: !hasFloatingLabel, // If floating label is selected, only show country flag without country code
+      separateDialCode: false, // If floating label is selected, only show country flag without country code
       initialCountry: initialCountry,
+      validationNumberTypes: ["FIXED_LINE_OR_MOBILE"],
     });
 
     if (hasFloatingLabel) {
@@ -40,6 +41,21 @@ Alpine.data('telInput', () => ({
     this.validationElement.innerText = logicValid ? this.requiredValidationMessage : this.logicValidationMessage;
     let classList = this.validationElement.classList;
     this.inputField.checkValidity() ? classList.remove('d-block') : classList.add('d-block');
+    // set Aria describedby attribute - also relevant in form.js and form-field.js
+    this.inputField.setAttribute("aria-invalid", !logicValid);
+    if (logicValid && !this.inputField.value.trim() === "") {
+      this.inputField.removeAttribute("aria-describedby");
+    } else if ("ariaDescribedByElements" in Element.prototype) {
+      var errorMessageElements = Array.from(
+        this.inputField
+          .closest(".bsi-form-element")
+          .querySelectorAll(".invalid-feedback")
+      ).filter(
+        (errorMessageElement) =>
+          window.getComputedStyle(errorMessageElement).display !== "none"
+      );
+      this.inputField.ariaDescribedByElements = errorMessageElements;
+    }
   },
 
   _initFloatingLabel() {

--- a/content-elements/form/form-field-tel/prototype/styles.scss
+++ b/content-elements/form/form-field-tel/prototype/styles.scss
@@ -14,6 +14,10 @@ $flagsImagePath: "~intl-tel-input/build/img/";
       .iti__dropdown-content {
         width: fit-content !important;
       }
+
+      .iti__tel-input {
+        margin-top: 0.5rem !important;
+      }
     }
 
     .form-floating .form-label {

--- a/content-elements/form/form-field-tel/prototype/template.twig
+++ b/content-elements/form/form-field-tel/prototype/template.twig
@@ -28,7 +28,7 @@
                     aria-label="{{ phoneInfoText }}"></i>
             </div>
             <input x-ref="inputField"
-                @change="validate"
+                @input="validate"
                 class="form-control bsi-form-tel-input-element"
                 id="tel-field"
                 type="tel"

--- a/content-elements/form/form-field/prototype/form-field.js
+++ b/content-elements/form/form-field/prototype/form-field.js
@@ -1,119 +1,174 @@
-import Alpine from '@alpinejs/csp';
+import Alpine from "@alpinejs/csp";
 import flatpickr from "flatpickr";
 import "flatpickr/dist/l10n/de.js";
 import "flatpickr/dist/l10n/fr.js";
 import "flatpickr/dist/l10n/it.js";
 
-Alpine.data('formField', () => ({
+Alpine.data("formField", () => ({
   inputEl: null,
   fp: null,
   minDate: null,
   maxDate: null,
   isTime: false,
-  requiredValidationMessage: '',
-  logicValidationMessage: '',
+  requiredValidationMessage: "",
+  logicValidationMessage: "",
   validationElement: null,
 
   init() {
-    this.validationElement = this.$root.querySelector('.invalid-feedback')
+    this.validationElement = this.$root.querySelector(".invalid-feedback");
     this.requiredValidationMessage = this.validationElement.innerText;
-    this.logicValidationMessage = this.$root.querySelector('.logic-validation').innerText;
+    this.logicValidationMessage =
+      this.$root.querySelector(".logic-validation").innerText;
   },
   initFormFieldInput() {
     this.inputEl = this.$el;
 
-    if (this.inputEl.type === 'range') {
+    if (this.inputEl.type === "range") {
       this._initRangeInput();
-    } else if (['date', 'datetime-local', 'time'].includes(this.inputEl.type)) {
+    } else if (["date", "datetime-local", "time"].includes(this.inputEl.type)) {
       this._initDateInput();
     }
 
-    if (this.inputEl.type === 'text' || this.inputEl.type === 'email' || this.inputEl.type === 'password') {
+    if (
+      this.inputEl.type === "text" ||
+      this.inputEl.type === "email" ||
+      this.inputEl.type === "password"
+    ) {
       if (!this.inputEl.hasAttribute("maxlength")) {
         this.inputEl.setAttribute("maxlength", 250);
       }
     }
 
-    if (this.inputEl.type === 'email') {
-      this.inputEl.setAttribute('pattern', '^[^@\\s]{1,}@[^@\\[\\]\\s]{1,}\\.[^@\\[\\]\\s]{2,}$');
+    if (this.inputEl.type === "email") {
+      this.inputEl.setAttribute(
+        "pattern",
+        "^[^@\\s]{1,}@[^@\\[\\]\\s]{1,}\\.[^@\\[\\]\\s]{2,}$"
+      );
     }
   },
 
   validateInput() {
     // TODO: replace by css - this is styling, not validation
-    if (this.inputEl.closest('.bsi-form-label-floating') && this.inputEl.classList.contains('flatpickr-input') && this.inputEl.value) {
-      let label = this.$root.querySelector('.form-label');
+    if (
+      this.inputEl.closest(".bsi-form-label-floating") &&
+      this.inputEl.classList.contains("flatpickr-input") &&
+      this.inputEl.value
+    ) {
+      let label = this.$root.querySelector(".form-label");
       label.style.opacity = 0.65;
-      label.style.transform = 'scale(0.85) translateY(-0.5rem) translateX(0.15rem)';
+      label.style.transform =
+        "scale(0.85) translateY(-0.5rem) translateX(0.15rem)";
     }
 
     this._validateDateTimeInput();
-    this.validationElement.innerText = !this.$el.checkValidity() && this.$el.value ? this.logicValidationMessage : this.requiredValidationMessage;
+    this.validationElement.innerText =
+      !this.$el.checkValidity() && this.$el.value
+        ? this.logicValidationMessage
+        : this.requiredValidationMessage;
+    // set Aria describedby attribute - also relevant in form.js and form-tel-input.js
+    this.inputEl.setAttribute("aria-invalid", !this.inputEl.checkValidity());
+    if (this.inputEl.checkValidity()) {
+      this.inputEl.removeAttribute("aria-describedby");
+    } else if ("ariaDescribedByElements" in Element.prototype) {
+      var errorMessageElements = Array.from(
+        this.inputEl
+          .closest(".bsi-form-element")
+          .querySelectorAll(".invalid-feedback")
+      ).filter(
+        (errorMessageElement) =>
+          window.getComputedStyle(errorMessageElement).display !== "none"
+      );
+      this.inputEl.ariaDescribedByElements = errorMessageElements;
+    }
   },
 
   _validateDateTimeInput() {
-    if (this.inputEl.classList.contains('flatpickr-input')) {
+    if (this.inputEl.classList.contains("flatpickr-input")) {
       let valid = true;
       if (this.inputEl.value && (this.inputEl.min || this.inputEl.max)) {
-        let valDate = new Date(this.isTime ? `2000-01-01T${this.inputEl.value}` : this.inputEl.value);
+        let valDate = new Date(
+          this.isTime ? `2000-01-01T${this.inputEl.value}` : this.inputEl.value
+        );
         valid = valid && (!this.minDate || valDate >= this.minDate);
         valid = valid && (!this.maxDate || valDate <= this.maxDate);
       }
-      this.inputEl.setCustomValidity(valid ? '' : this.logicValidationMessage);
+      this.inputEl.setCustomValidity(valid ? "" : this.logicValidationMessage);
     }
   },
 
   // Adjust range input to bootstrap styling
   _initRangeInput() {
-    this.inputEl.classList.add('form-range');
-    this.inputEl.classList.remove('form-control');
+    this.inputEl.classList.add("form-range");
+    this.inputEl.classList.remove("form-control");
   },
 
   _initDateInput() {
-    let locale = document.documentElement.lang.slice(0, 2) ?? 'de-CH';
+    let locale = document.documentElement.lang.slice(0, 2) ?? "de-CH";
     var type = this.inputEl.type;
-    this.isTime = (type === 'time');
+    this.isTime = type === "time";
     if (this.inputEl.placeholder && !this.isTime) {
-      var twoDigitNumber = (number) => number.toString().padStart(2, '0');
+      var twoDigitNumber = (number) => number.toString().padStart(2, "0");
       let date = new Date(this.inputEl.placeholder);
       let day = twoDigitNumber(date.getDate());
       let month = twoDigitNumber(date.getMonth() + 1); // month is 0 indexed
       let year = date.getFullYear();
       let hours = twoDigitNumber(date.getHours());
       let minutes = twoDigitNumber(date.getMinutes());
-      this.inputEl.placeholder = (type === 'date') ? `${day}.${month}.${year}` : `${day}.${month}.${year} ${hours}:${minutes}`;
+      this.inputEl.placeholder =
+        type === "date"
+          ? `${day}.${month}.${year}`
+          : `${day}.${month}.${year} ${hours}:${minutes}`;
+    } else if (!this.inputEl.placeholder) {
+      this.inputEl.placeholder =
+        type === "date"
+          ? "TT.mm.jjjj"
+          : type === "datetime-local"
+          ? "TT.mm.jjj --:--"
+          : "--:--";
     }
 
-    this.minDate = this.inputEl.min ? new Date(this.isTime ? `2000-01-01T${this.inputEl.min}` : this.inputEl.min) : null;
-    this.maxDate = this.inputEl.max ? new Date(this.isTime ? `2000-01-01T${this.inputEl.max}` : this.inputEl.max) : null;
+    this.minDate = this.inputEl.min
+      ? new Date(
+          this.isTime ? `2000-01-01T${this.inputEl.min}` : this.inputEl.min
+        )
+      : null;
+    this.maxDate = this.inputEl.max
+      ? new Date(
+          this.isTime ? `2000-01-01T${this.inputEl.max}` : this.inputEl.max
+        )
+      : null;
 
     var dateFormats = {
-      'date': 'Y-m-d',
-      'datetime-local': 'Y-m-dTH:i',
-      'time': 'H:i'
+      date: "Y-m-d",
+      "datetime-local": "Y-m-dTH:i",
+      time: "H:i",
     };
     var altFormats = {
-      'date': 'd.m.Y',
-      'datetime-local': 'd.m.Y H:i',
-      'time': 'H:i'
+      date: "d.m.Y",
+      "datetime-local": "d.m.Y H:i",
+      time: "H:i",
     };
     this.fp = flatpickr(this.inputEl, {
       locale: locale,
       altInput: true,
       altFormat: altFormats[type],
       dateFormat: dateFormats[type],
-      allowInput: true,
-      enableTime: type !== 'date',
+      allowInput: this.inputEl.classList.contains("allowInput"),
+      enableTime: type !== "date",
       noCalendar: this.isTime,
       time_24hr: true,
       minDate: this.minDate,
-      maxDate: this.maxDate
+      maxDate: this.maxDate,
     });
 
+    this.inputEl.closest(".input-container").querySelector(".input").id = this.inputEl.id;
+    this.inputEl.removeAttribute("id");
     // Add the span (with the icon) after the input
-    this.inputEl.parentNode.classList.add('input-container'); // Add the container class in order to set the icon position
-    var iconSpan = document.createElement('span');
-    iconSpan.innerHTML = `<i class="bi ${this.isTime ? 'bi-clock' : 'bi-calendar'}"></i>`;
+    this.inputEl.parentNode.classList.add("input-container"); // Add the container class in order to set the icon position
+    var iconSpan = document.createElement("span");
+    iconSpan.innerHTML = `<i class="bi ${
+      this.isTime ? "bi-clock" : "bi-calendar"
+    }"></i>`;
     this.inputEl.parentNode.appendChild(iconSpan);
   },
-}))
+}));

--- a/content-elements/form/form-field/prototype/form-field.js
+++ b/content-elements/form/form-field/prototype/form-field.js
@@ -10,102 +10,93 @@ Alpine.data("formField", () => ({
   minDate: null,
   maxDate: null,
   isTime: false,
-  requiredValidationMessage: "",
-  logicValidationMessage: "",
+  requiredValidationMessage: '',
+  logicValidationMessage: '',
   validationElement: null,
 
   init() {
-    this.validationElement = this.$root.querySelector(".invalid-feedback");
+    this.validationElement = this.$root.querySelector('.invalid-feedback');
     this.requiredValidationMessage = this.validationElement.innerText;
-    this.logicValidationMessage =
-      this.$root.querySelector(".logic-validation").innerText;
+    this.logicValidationMessage = this.$root.querySelector('.logic-validation').innerText;
   },
   initFormFieldInput() {
     this.inputEl = this.$el;
 
-    if (this.inputEl.type === "range") {
+    if (this.inputEl.type === 'range') {
       this._initRangeInput();
-    } else if (["date", "datetime-local", "time"].includes(this.inputEl.type)) {
+    } else if (['date', 'datetime-local', 'time'].includes(this.inputEl.type)) {
       this._initDateInput();
     }
 
     if (
-      this.inputEl.type === "text" ||
-      this.inputEl.type === "email" ||
-      this.inputEl.type === "password"
+      this.inputEl.type === 'text' ||
+      this.inputEl.type === 'email' ||
+      this.inputEl.type === 'password'
     ) {
-      if (!this.inputEl.hasAttribute("maxlength")) {
-        this.inputEl.setAttribute("maxlength", 250);
+      if (!this.inputEl.hasAttribute('maxlength')) {
+        this.inputEl.setAttribute('maxlength', 250);
       }
     }
 
-    if (this.inputEl.type === "email") {
-      this.inputEl.setAttribute(
-        "pattern",
-        "^[^@\\s]{1,}@[^@\\[\\]\\s]{1,}\\.[^@\\[\\]\\s]{2,}$"
-      );
+    if (this.inputEl.type === 'email') {
+      this.inputEl.setAttribute('pattern', '^[^@\\s]{1,}@[^@\\[\\]\\s]{1,}\\.[^@\\[\\]\\s]{2,}$');
     }
   },
 
   validateInput() {
     // TODO: replace by css - this is styling, not validation
     if (
-      this.inputEl.closest(".bsi-form-label-floating") &&
-      this.inputEl.classList.contains("flatpickr-input") &&
+      this.inputEl.closest('.bsi-form-label-floating') &&
+      this.inputEl.classList.contains('flatpickr-input') &&
       this.inputEl.value
     ) {
-      let label = this.$root.querySelector(".form-label");
+      let label = this.$root.querySelector('.form-label');
       label.style.opacity = 0.65;
-      label.style.transform =
-        "scale(0.85) translateY(-0.5rem) translateX(0.15rem)";
+      label.style.transform = 'scale(0.85) translateY(-0.5rem) translateX(0.15rem)';
     }
 
     this._validateDateTimeInput();
-    this.validationElement.innerText =
-      !this.$el.checkValidity() && this.$el.value
+    this.validationElement.innerText = !this.$el.checkValidity() 
+      && this.$el.value
         ? this.logicValidationMessage
         : this.requiredValidationMessage;
     // set Aria describedby attribute - also relevant in form.js and form-tel-input.js
-    this.inputEl.setAttribute("aria-invalid", !this.inputEl.checkValidity());
+    this.inputEl.setAttribute('aria-invalid', !this.inputEl.checkValidity());
     if (this.inputEl.checkValidity()) {
-      this.inputEl.removeAttribute("aria-describedby");
-    } else if ("ariaDescribedByElements" in Element.prototype) {
+      this.inputEl.removeAttribute('aria-describedby');
+    } else if ('ariaDescribedByElements' in Element.prototype) {
       var errorMessageElements = Array.from(
         this.inputEl
-          .closest(".bsi-form-element")
-          .querySelectorAll(".invalid-feedback")
-      ).filter(
-        (errorMessageElement) =>
-          window.getComputedStyle(errorMessageElement).display !== "none"
-      );
+          .closest('.bsi-form-element')
+          .querySelectorAll('.invalid-feedback'))
+      .filter(
+        (errorMessageElement) => window.getComputedStyle(errorMessageElement).display !== 'none');
       this.inputEl.ariaDescribedByElements = errorMessageElements;
     }
   },
 
   _validateDateTimeInput() {
-    if (this.inputEl.classList.contains("flatpickr-input")) {
+    if (this.inputEl.classList.contains('flatpickr-input')) {
       let valid = true;
       if (this.inputEl.value && (this.inputEl.min || this.inputEl.max)) {
-        let valDate = new Date(
-          this.isTime ? `2000-01-01T${this.inputEl.value}` : this.inputEl.value
-        );
+        let valDate = new Date(this.isTime ? `2000-01-01T${this.inputEl.value}` : this.inputEl.value);
         valid = valid && (!this.minDate || valDate >= this.minDate);
         valid = valid && (!this.maxDate || valDate <= this.maxDate);
       }
-      this.inputEl.setCustomValidity(valid ? "" : this.logicValidationMessage);
+      this.inputEl.setCustomValidity(valid ? '' : this.logicValidationMessage);
     }
   },
 
   // Adjust range input to bootstrap styling
   _initRangeInput() {
-    this.inputEl.classList.add("form-range");
-    this.inputEl.classList.remove("form-control");
+    this.inputEl.classList.add('form-range');
+    this.inputEl.classList.remove('form-control');
   },
 
   _initDateInput() {
-    let locale = document.documentElement.lang.slice(0, 2) ?? "de-CH";
+    let locale = document.documentElement.lang.slice(0, 2) ?? 'de-CH';
     var type = this.inputEl.type;
-    this.isTime = type === "time";
+    this.isTime = type === 'time';
     if (this.inputEl.placeholder && !this.isTime) {
       var twoDigitNumber = (number) => number.toString().padStart(2, "0");
       let date = new Date(this.inputEl.placeholder);
@@ -115,16 +106,16 @@ Alpine.data("formField", () => ({
       let hours = twoDigitNumber(date.getHours());
       let minutes = twoDigitNumber(date.getMinutes());
       this.inputEl.placeholder =
-        type === "date"
+        type === 'date'
           ? `${day}.${month}.${year}`
           : `${day}.${month}.${year} ${hours}:${minutes}`;
     } else if (!this.inputEl.placeholder) {
       this.inputEl.placeholder =
-        type === "date"
-          ? "TT.mm.jjjj"
-          : type === "datetime-local"
-          ? "TT.mm.jjj --:--"
-          : "--:--";
+        type === 'date'
+          ? 'TT.mm.jjjj'
+          : type === 'datetime-local'
+          ? 'TT.mm.jjj --:--'
+          : '--:--';
     }
 
     this.minDate = this.inputEl.min
@@ -139,35 +130,33 @@ Alpine.data("formField", () => ({
       : null;
 
     var dateFormats = {
-      date: "Y-m-d",
-      "datetime-local": "Y-m-dTH:i",
-      time: "H:i",
+      date: 'Y-m-d', 'datetime-local': 'Y-m-dTH:i',
+      time: 'H:i',
     };
     var altFormats = {
-      date: "d.m.Y",
-      "datetime-local": "d.m.Y H:i",
-      time: "H:i",
+      date: 'd.m.Y', 'datetime-local': 'd.m.Y H:i',
+      time: 'H:i',
     };
     this.fp = flatpickr(this.inputEl, {
       locale: locale,
       altInput: true,
       altFormat: altFormats[type],
       dateFormat: dateFormats[type],
-      allowInput: this.inputEl.classList.contains("allowInput"),
-      enableTime: type !== "date",
+      allowInput: this.inputEl.classList.contains('allowInput'),
+      enableTime: type !== 'date',
       noCalendar: this.isTime,
       time_24hr: true,
       minDate: this.minDate,
       maxDate: this.maxDate,
     });
 
-    this.inputEl.closest(".input-container").querySelector(".input").id = this.inputEl.id;
-    this.inputEl.removeAttribute("id");
+    this.inputEl.closest('.input-container').querySelector('.input').id = this.inputEl.id;
+    this.inputEl.removeAttribute('id');
     // Add the span (with the icon) after the input
-    this.inputEl.parentNode.classList.add("input-container"); // Add the container class in order to set the icon position
-    var iconSpan = document.createElement("span");
+    this.inputEl.parentNode.classList.add('input-container'); // Add the container class in order to set the icon position
+    var iconSpan = document.createElement('span');
     iconSpan.innerHTML = `<i class="bi ${
-      this.isTime ? "bi-clock" : "bi-calendar"
+      this.isTime ? 'bi-clock' : 'bi-calendar'
     }"></i>`;
     this.inputEl.parentNode.appendChild(iconSpan);
   },

--- a/content-elements/form/form-field/prototype/styles.scss
+++ b/content-elements/form/form-field/prototype/styles.scss
@@ -1,5 +1,6 @@
 @import "flatpickr/dist/flatpickr";
 @import "bootstrap-icons/font/bootstrap-icons.css";
+
 @mixin styles($id: 'form-field-REEhtN') {
   .bsi-element-#{$id} {
     .flatpickr-input {
@@ -9,18 +10,19 @@
         background-color: #fff;
       }
     }
+
     .input-container {
       position: relative;
     }
-    
+
     .input-container input {
       width: 100%;
       padding-right: 30px;
     }
-    
+
     .input-container i {
       position: absolute;
-      right: 30px; 
+      right: 30px;
       top: 50%;
       transform: translateY(-50%);
       cursor: pointer;
@@ -49,8 +51,14 @@
         background-color: rgba(0, 0, 0, 0.05) !important;
       }
     }
+
+
   }
-  
+
+  .was-validated .bsi-element-#{$id} .input-container:has(input:invalid) .invalid-feedback {
+    display: block;
+  }
+
   @media screen and (prefers-color-scheme: dark) {
     .form-label {
       color: bsiProperty('darkModeTextColor', #ffffff);

--- a/content-elements/form/form-field/prototype/template.twig
+++ b/content-elements/form/form-field/prototype/template.twig
@@ -26,7 +26,7 @@
 			<i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-custom-class="bsi-tooltip" role="tooltip" aria-label="{{ formFieldInfoText }}"></i>
 		</div>
 		<div class="input-container">
-			<div class="input-fild-and-icon-container">
+			<div class="input-field-and-icon-container">
 				<input x-init="initFormFieldInput" x-on:input="validateInput" type="text" class="form-control bsi-form-field-input {{ properties.flatpickrInput }}" id="field" value="">
 			</div>
 			<div data-bsi-element-part="{{ formFieldErrorRequiredPartId }}" class="invalid-feedback">

--- a/content-elements/form/form-field/prototype/template.twig
+++ b/content-elements/form/form-field/prototype/template.twig
@@ -26,7 +26,9 @@
 			<i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-custom-class="bsi-tooltip" role="tooltip" aria-label="{{ formFieldInfoText }}"></i>
 		</div>
 		<div class="input-container">
-			<input x-init="initFormFieldInput" x-on:change="validateInput" type="text" class="form-control bsi-form-field-input" id="field" value="">
+			<div class="input-fild-and-icon-container">
+				<input x-init="initFormFieldInput" x-on:input="validateInput" type="text" class="form-control bsi-form-field-input {{ properties.flatpickrInput }}" id="field" value="">
+			</div>
 			<div data-bsi-element-part="{{ formFieldErrorRequiredPartId }}" class="invalid-feedback">
 				{{ formFieldErrorRequiredText }}
 			</div>

--- a/styles/properties.scss
+++ b/styles/properties.scss
@@ -61,6 +61,9 @@ $lg: bsiProperty('gridBreakpointLG', 940px);
 $xl: bsiProperty('gridBreakpointXL', 1200px);
 $xxl: bsiProperty('gridBreakpointXXL', 1400px);
 
+//Flatpickr
+$flatpickrInput: bsiProperty('flatpickrInput', 'allowInput');
+
 
 /* -------------- Customizing bootstrap variables -------------- */
 


### PR DESCRIPTION
- Fehlermeldungen werden nun auch von Screenreadern vorgelesen (aria-describedby)
- Das Telefonnummernfeld hat noch kleine Anpassungen erhalten: 
  - Vorwahl ausgeschaltet, da diese sonst teilweise doppelt angezeigt wurde
  - Validierung der Nummer auf für Festnetznummern freigeschaltet
- per Properties ist nun einstellbar, ob das Datumsfeld einen direkten Input über die Tastatur erlaubt oder nicht
  - Standardwert ist hier "allowInput"
  - Bei "notAllowInput" funktioniert momentan unsere Validierung noch nicht, da die Bibliothek das Feld dann auf readonly setzt und ein input feld mit readonly immer valid ist.