### PR TITLE
#430677: re-add floating labels option for forms

### DIFF
--- a/configs/styles/form-label.js
+++ b/configs/styles/form-label.js
@@ -12,4 +12,8 @@ module.exports = cx.style
     cx.cssClass
       /*.withLabel('Left')*/
       .withLabel('Links')
-      .withCssClass('bsi-form-label-left'));
+      .withCssClass('bsi-form-label-left'),
+    cx.cssClass
+      /*.withLabel('Floating')*/
+      .withLabel('Schwebend')
+      .withCssClass('bsi-form-label-floating'));


### PR DESCRIPTION
Revert change from https://github.com/bsi-software/bsi-cx-design-standard-library-web/pull/176/files#diff-c6375d952e283f704746c346f00f4b2f6f6384a7878083376bbedb1ead9d6675L19.. Re-add floating label option to fix this breaking change.